### PR TITLE
Simplify jq command

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-HOST=$(tailscale status --json | jq .Self.DNSName | tr -d \" | cut -d\. -f 1)
+HOST=$(tailscale status --json | jq -r '.Self.DNSName | split(".") | first')
 if [[ "$HOST" == "leonard" ]]
 then
   echo "Starting with prod config on $HOST"


### PR DESCRIPTION
We don't need `tr` and `cut` for things `jq` can do.

```
  [fg-386] transitquality > echo '{"Self": { "DNSName": "prod.my.hostname.com" } }' | jq -r '.Self.DNSName | split(".") | first'
prod
```